### PR TITLE
feat: Add types for UI component props

### DIFF
--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
-
+import { cva } from "class-variance-authority"
 import { cn } from "@/lib/utils"
+import type { ButtonProps } from "@/types/ui-components"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
@@ -30,12 +30,6 @@ const buttonVariants = cva(
   },
 )
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean
-}
-
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
@@ -45,4 +39,3 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = "Button"
 
 export { Button, buttonVariants }
-

--- a/web/src/types/ui-components.ts
+++ b/web/src/types/ui-components.ts
@@ -1,0 +1,39 @@
+import * as React from "react"
+
+/**
+ * Base props that all UI components should extend
+ */
+export interface BaseProps {
+  className?: string
+  children?: React.ReactNode
+}
+
+/**
+ * Button variant types
+ */
+export type ButtonVariant = 
+  | "default" 
+  | "destructive" 
+  | "outline" 
+  | "secondary" 
+  | "ghost" 
+  | "link"
+
+/**
+ * Button size types
+ */
+export type ButtonSize = 
+  | "default" 
+  | "sm" 
+  | "lg" 
+  | "icon"
+
+/**
+ * Props for Button component
+ */
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  asChild?: boolean
+  className?: string
+}


### PR DESCRIPTION
# Add TypeScript Types for UI Components

## Description
Added proper TypeScript interfaces for UI component props to resolve compilation errors and improve code maintainability.

## Changes Made
- Created `web/src/types/ui-components.ts` with base interfaces and specific component types
- Implemented `ButtonProps` interface extending HTML button attributes
- Added type definitions for button variants and sizes
- Updated `web/src/components/ui/button.tsx` to use the new typed props

## Benefits
- ✅ Resolves TypeScript compilation errors
- ✅ Improves code maintainability and developer experience
- ✅ Provides better IntelliSense and autocomplete
- ✅ Ensures type safety for component props

closes #155


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Centralized shared UI component prop types, introducing common base props and standardized button variants and sizes for consistency.
  - Updated the button component to use shared types, simplifying imports and reducing dependency surface.
  - Improves type safety and maintainability across UI components.
  - No functional or visual changes; existing buttons continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->